### PR TITLE
DateTime() doesn't create a fixed time object

### DIFF
--- a/Chandra/Time.py
+++ b/Chandra/Time.py
@@ -666,6 +666,13 @@ class DateTime(object):
     :returns: DateTime object
     """
     def __init__(self, time_in=None, format=None):
+        # If no time_in supplied this implies NOW.
+        if time_in is None:
+            if format is not None:
+                raise ValueError('Cannot supply `format` without `time_in`')
+            time_in = time.time()
+            format = 'unix'
+
         try:
             self.time_in = time_in.time_in
             self.format = time_in.format

--- a/Chandra/test_Time.py
+++ b/Chandra/test_Time.py
@@ -1,6 +1,7 @@
 import Chandra.Time
 from Chandra.Time import DateTime, convert, convert_vals, date2secs, secs2date
 import unittest
+import time
 
 try:
     import numpy as np
@@ -159,6 +160,16 @@ class TestConvert(unittest.TestCase):
         self.assertEqual(date1.date, date2.date)
         date1 = DateTime('2001:180:00:00:00')
         self.assertAlmostEqual(date1.frac_year, 2001 + 179. / 365.)
+
+    def test_date_now(self):
+        """
+        Make sure that instantiating a DateTime object as NOW uses the
+        the time at creation, not the time at attribute access.
+        """
+        date1 = DateTime()
+        date1_date = date1.date
+        time.sleep(1)
+        self.assertEqual(date1.date, date1_date)
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='Chandra.Time',
       description='Convert between various time formats relevant to Chandra',
       author_email = 'taldcroft@cfa.harvard.edu',
       py_modules = ['Chandra.axTime3', 'Chandra.Time'],
-      version='1.16.1',
+      version='1.16.2',
       zip_safe=False,
       test_suite = "Chandra.test_Time",
 


### PR DESCRIPTION
The DateTime() method with no input args doesn't seem to initialize a structure to store the fixed time of "now" and instead appears to keep getting the current time.  This is not the expected behavior.

```
In [1]: from Chandra.Time import DateTime
In [2]: d = DateTime()
In [3]: d.secs
Out[3]: 530297635.8762741
In [4]: d.secs
Out[4]: 530297637.86023587
In [5]: d.secs
Out[5]: 530297639.47543186
