### PR TITLE
Use AlmostEqual on tests for 32 bit compatibility

### DIFF
--- a/Chandra/Time/__init__.py
+++ b/Chandra/Time/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .Time import *
 
-__version__ = '3.20.1'
+__version__ = '3.20.2'
 
 
 def test(*args, **kwargs):

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -80,7 +80,8 @@ class TestConvert(unittest.TestCase):
     def test_secs(self):
         self.assertEqual('%.3f' % DateTime(20483020.).secs, '20483020.000')
         self.assertEqual(DateTime(20483020.).date, '1998:238:01:42:36.816')
-        self.assertEqual(DateTime('2012:001:00:00:00.000').secs, 441763266.18399996)
+        self.assertAlmostEqual(DateTime('2012:001:00:00:00.000').secs,
+                         441763266.18399996, places=6)
         self.assertEqual(DateTime(473385667.18399996).date, '2013:001:00:00:00.000')
 
     def test_fits2secs(self):


### PR DESCRIPTION
Use AlmostEqual on tests to relax one for 32 bit compatibility