### PR TITLE
Add compile arg for building on MacOS Catalina / Xcode 11.2

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/Chandra/Time/__init__.py
+++ b/Chandra/Time/__init__.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import ska_helpers
+
 from .Time import *
 
-__version__ = '3.20.3'
+__version__ = ska_helpers.get_version(__package__)
 
 
 def test(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from setuptools import setup, Extension
 
-import os
+import platform
 from Cython.Build import cythonize
 
-if (os.name == "nt"):
+os_name = platform.system()
+if (os_name == "Windows"):
     compile_args = ['/EHs', '/D_CRT_SECURE_NO_DEPRECATE']
 else:
     compile_args = ['-Wno-switch-enum', '-Wno-switch', '-Wno-switch-default',
                     '-Wno-deprecated', '-Wno-parentheses']
+if os_name == 'Darwin':
+    compile_args += ['-stdlib=libc++']
 
 extensions = [Extension("*", ["Chandra/Time/_axTime3.pyx"],
                         extra_compile_args=compile_args)]

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ from setuptools import setup, Extension
 import os
 from Cython.Build import cythonize
 
-from Chandra.Time import __version__
-
 if (os.name == "nt"):
     compile_args = ['/EHs', '/D_CRT_SECURE_NO_DEPRECATE']
 else:
@@ -24,7 +22,8 @@ setup(name='Chandra.Time',
       author='Tom Aldcroft',
       description='Convert between various time formats relevant to Chandra',
       author_email='taldcroft@cfa.harvard.edu',
-      version=__version__,
+      use_scm_version=True,
+      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       zip_safe=False,
       packages=['Chandra', 'Chandra.Time', 'Chandra.Time.tests'],
       ext_modules=cythonize(extensions),


### PR DESCRIPTION
This is apparently needed to allow building Chandra.Time with the latest OS / tools on MacOS.

This includes and thus supercedes #36.

## Testing
- [x] CentOS-5: `python setup.py test` in a clean directory builds OK and passes tests on `presto`
- [x] MacOS Catalina / Xcode 11.2
- [x] MacOS High Sierra / Xcode (on machine aca@zero)
- [x] MacOS Mojave [TA will do]

Closes #36