### PR TITLE
Fix the location of the C extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 if os_name == 'Darwin':
     compile_args += ['-stdlib=libc++']
 
-extensions = [Extension("*", ["Chandra/Time/_axTime3.pyx"],
+extensions = [Extension("Chandra.Time._axTime3", ["Chandra/Time/_axTime3.pyx"],
                         extra_compile_args=compile_args)]
 
 try:


### PR DESCRIPTION
## Description

After the namespace module changes, it turned out the _axTime3 C extension was being installed in site-packages/Time instead of site-packages/Chandra/Time. This PR fixes that.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing (no functional tests were made)

Fixes #