### PR TITLE
Allow setup.py --version to work without Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
 from setuptools import setup, Extension
 
 import platform
-try:
-    from Cython.Build import cythonize
-except ImportError:
+# Special case here to allow `python setup.py --version` to run without
+# requiring cython and numpy to be installed.
+if '--version' in sys.argv[1:]:
     cythonize = lambda arg: None
+else:
+    from Cython.Build import cythonize
 
 os_name = platform.system()
 if (os_name == "Windows"):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 from setuptools import setup, Extension
 
 import platform
-from Cython.Build import cythonize
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = lambda arg: None
 
 os_name = platform.system()
 if (os_name == "Windows"):


### PR DESCRIPTION
## Description

This addresses the problem in https://github.com/sot/skare3/issues/255.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing:

~~(BTW, I note still getting `Warning: Extension name 'Chandra.Time._axTime3' does not match fully qualified name 'Time._axTime3' of 'Chandra/Time/_axTime3.pyx'`~~ (fixed upstream in newer Cython version).

### Getting version in a cython-free environment
```
(ska3) ➜  chandra.time git:(cython) ✗ conda create -n test-min python=3.6 setuptools_scm  
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /Users/aldcroft/miniconda3/envs/test-min

  added / updated specs:
    - python=3.6
    - setuptools_scm


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    certifi-2020.4.5.1         |           py36_0         155 KB
    python-3.6.10              |       hc70fcce_1        17.1 MB
    readline-8.0               |       h1de35cc_0         326 KB
    setuptools-46.1.3          |           py36_0         511 KB
    ------------------------------------------------------------
                                           Total:        18.1 MB

The following NEW packages will be INSTALLED:

  ca-certificates    pkgs/main/osx-64::ca-certificates-2020.1.1-0
  certifi            pkgs/main/osx-64::certifi-2020.4.5.1-py36_0
  libcxx             pkgs/main/osx-64::libcxx-4.0.1-hcfea43d_1
  libcxxabi          pkgs/main/osx-64::libcxxabi-4.0.1-hcfea43d_1
  libedit            pkgs/main/osx-64::libedit-3.1.20181209-hb402a30_0
  libffi             pkgs/main/osx-64::libffi-3.2.1-h475c297_4
  ncurses            pkgs/main/osx-64::ncurses-6.2-h0a44026_0
  openssl            pkgs/main/osx-64::openssl-1.1.1f-h1de35cc_0
  pip                pkgs/main/osx-64::pip-20.0.2-py36_1
  python             pkgs/main/osx-64::python-3.6.10-hc70fcce_1
  readline           pkgs/main/osx-64::readline-8.0-h1de35cc_0
  setuptools         pkgs/main/osx-64::setuptools-46.1.3-py36_0
  setuptools_scm     pkgs/main/noarch::setuptools_scm-3.4.3-py_0
  sqlite             pkgs/main/osx-64::sqlite-3.31.1-ha441bb4_0
  tk                 pkgs/main/osx-64::tk-8.6.8-ha441bb4_0
  wheel              pkgs/main/osx-64::wheel-0.34.2-py36_0
  xz                 pkgs/main/osx-64::xz-5.2.4-h1de35cc_4
  zlib               pkgs/main/osx-64::zlib-1.2.11-h1de35cc_3


Proceed ([y]/n)? y


Downloading and Extracting Packages
python-3.6.10        | 17.1 MB   | ###################################################################### | 100% 
setuptools-46.1.3    | 511 KB    | ###################################################################### | 100% 
certifi-2020.4.5.1   | 155 KB    | ###################################################################### | 100% 
readline-8.0         | 326 KB    | ###################################################################### | 100% 
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate test-min
#
# To deactivate an active environment, use
#
#     $ conda deactivate

(ska3) ➜  chandra.time git:(cython) ✗ conda activate test-min
(test-min) ➜  chandra.time git:(cython) ✗ 
(test-min) ➜  chandra.time git:(cython) ✗ 
(test-min) ➜  chandra.time git:(cython) ✗ git cleans -fxd
Removing .eggs/
Removing Chandra/Time/_axTime3.cpp
Removing Chandra/Time/_axTime3.cpython-36m-darwin.so
Removing build/
(test-min) ➜  chandra.time git:(cython) ✗ python setup.py --version
3.20.6.dev2+g9fca240.d20200412

(test-min) ➜  Chandra.Time git:(cython) ✗ python setup.py test     
Traceback (most recent call last):  File "setup.py", line 11, in <module>
    from Cython.Build import cythonize
ModuleNotFoundError: No module named 'Cython'
(test-min) ➜ 
```

### Building / test in ska3
```
(ska3) ➜  chandra.time git:(cython) python setup.py test  
Warning: Extension name 'Chandra.Time._axTime3' does not match fully qualified name 'Time._axTime3' of 'Chandra/Time/_axTime3.pyx'
Compiling Chandra/Time/_axTime3.pyx because it changed.
[1/1] Cythonizing Chandra/Time/_axTime3.pyx
running test
running egg_info
creating Chandra.Time.egg-info
writing Chandra.Time.egg-info/PKG-INFO
writing dependency_links to Chandra.Time.egg-info/dependency_links.txt
writing top-level names to Chandra.Time.egg-info/top_level.txt
writing manifest file 'Chandra.Time.egg-info/SOURCES.txt'
package init file 'Chandra/__init__.py' not found (or not a regular file)
reading manifest template 'MANIFEST.in'
writing manifest file 'Chandra.Time.egg-info/SOURCES.txt'
running build_ext
building 'Chandra.Time._axTime3' extension
creating build
creating build/temp.macosx-10.7-x86_64-3.6
creating build/temp.macosx-10.7-x86_64-3.6/Chandra
creating build/temp.macosx-10.7-x86_64-3.6/Chandra/Time
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -IChandra/Time -I/Users/aldcroft/miniconda3/envs/ska3/include/python3.6m -c Chandra/Time/_axTime3.cpp -o build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/_axTime3.o -Wno-switch-enum -Wno-switch -Wno-switch-default -Wno-deprecated -Wno-parentheses -stdlib=libc++
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -IChandra/Time -I/Users/aldcroft/miniconda3/envs/ska3/include/python3.6m -c Chandra/Time/axTime3.cc -o build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/axTime3.o -Wno-switch-enum -Wno-switch -Wno-switch-default -Wno-deprecated -Wno-parentheses -stdlib=libc++
Chandra/Time/axTime3.cc:380:11: warning: unused variable 'fgets_value' [-Wunused-variable]
    char* fgets_value = fgets (tform, 10, stdin) ;
          ^
Chandra/Time/axTime3.cc:56:26: warning: unused variable 'rcsid' [-Wunused-const-variable]
static const char* const rcsid = "axTime $Id: axTime3.cc,v 1.2 2007-08-27 21:30:59 aldcroft Exp $" ;
                         ^
2 warnings generated.
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -I/Users/aldcroft/miniconda3/envs/ska3/include -arch x86_64 -IChandra/Time -I/Users/aldcroft/miniconda3/envs/ska3/include/python3.6m -c Chandra/Time/XTime.cc -o build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/XTime.o -Wno-switch-enum -Wno-switch -Wno-switch-default -Wno-deprecated -Wno-parentheses -stdlib=libc++
Chandra/Time/XTime.cc:782:18: warning: field 'empty' will be initialized after field 'tr' [-Wreorder]
  : numXTRs (1), empty (1), tr (0) {
                 ^
1 warning generated.
creating build/lib.macosx-10.7-x86_64-3.6
creating build/lib.macosx-10.7-x86_64-3.6/Chandra
creating build/lib.macosx-10.7-x86_64-3.6/Chandra/Time
g++ -bundle -undefined dynamic_lookup -L/Users/aldcroft/miniconda3/envs/ska3/lib -L/Users/aldcroft/miniconda3/envs/ska3/lib -arch x86_64 build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/_axTime3.o build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/axTime3.o build/temp.macosx-10.7-x86_64-3.6/Chandra/Time/XTime.o -L/Users/aldcroft/miniconda3/envs/ska3/lib -o build/lib.macosx-10.7-x86_64-3.6/Chandra/Time/_axTime3.cpython-36m-darwin.so
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
copying build/lib.macosx-10.7-x86_64-3.6/Chandra/Time/_axTime3.cpython-36m-darwin.so -> Chandra/Time
============================================== test session starts ==============================================
platform darwin -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /Users/aldcroft/git/Chandra.Time, inifile:
plugins: remotedata-0.3.0, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
collected 30 items                                                                                               

Chandra/Time/tests/test_Time.py ..............................

=========================================== 30 passed in 1.60 seconds ===========================================
```


Fixes #255