### PR TITLE
Support CxoTime in DateTime and modernize

### DIFF
--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -595,11 +595,20 @@ def convert(time_in, sys_in=None, fmt_in=None, sys_out=None, fmt_out='secs'):
         fmt_in = 'unix'
         sys_in = None
 
+    # Special case for CxoTime so array input turns into one array-valued CxoTime.
+    # Otherwise one gets an array of CxoTime objects.
+    if fmt_out == 'cxotime':
+        from cxotime import CxoTime
+        time_out = [_convert(x, sys_in, fmt_in, sys_out='tt', fmt_out='secs')
+                    for x in time_in.flatten()]
+        time_out = CxoTime(time_out)
+        time_out.shape = time_in.shape
+        return time_out
+
     # Does is behave like a numpy ndarray with non-zero dimension?
     if hasattr(time_in, 'shape') and hasattr(time_in, 'flatten') and time_in.shape:
-        import numpy
         time_out = [_convert(x, sys_in, fmt_in, sys_out, fmt_out) for x in time_in.flatten()]
-        return numpy.array(time_out).reshape(time_in.shape)
+        return np.array(time_out).reshape(time_in.shape)
     else:
         # If time_in is not string-like then try iterating over it
         try:
@@ -666,7 +675,8 @@ def _convert(time_in, sys_in, fmt_in, sys_out, fmt_out):
                                     ax3_fmt_out,
                                     )
 
-    if postprocess: time_out = postprocess(time_out)
+    if postprocess:
+        time_out = postprocess(time_out)
 
     return time_out
 

--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -288,12 +288,6 @@ def date_to_greta(date_in):
     return out
 
 
-def secs_to_cxotime(date_in):
-    # date_in is a string repr of a float
-    from cxotime import CxoTime
-    return CxoTime(float(date_in), format='secs')
-
-
 # Conversions for frac_year format
 _year_secs = {}                 # Start and end secs for a year
 def year_start_end_secs(year):
@@ -374,7 +368,6 @@ time_styles = [ TimeStyle(name       = 'fits',
                           match_err  = AttributeError,
                           ax3_fmt    = 's',
                           ax3_sys    = 'm',
-                          postprocess= secs_to_cxotime,
                           ),
                 TimeStyle(name       = 'frac_year',
                           match_expr = '^' + RE['float'] + '$',

--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -182,7 +182,6 @@ day of year (1-366), and day of week (0-6, where 0 is Monday).
 
 These are all referenced to UTC time.
 """
-import sys
 import re
 from functools import wraps
 import warnings
@@ -207,28 +206,15 @@ def override__dir__(f):
     def __dir__(self):
         return ['special_method1', 'special_method2']
 
-    This method is copied from astropy.utils.compat.misc, with a slight change to
-    remove the six dependency.
+    This method is copied from astropy.utils.compat.misc.
     """
-    if sys.version_info[:2] < (3, 3):
-        # There was no straightforward way to do this until Python 3.3, so
-        # we have this complex monstrosity
-        @wraps(f)
-        def override__dir__wrapper(self):
-            members = set()
-            for cls in self.__class__.mro():
-                members.update(dir(cls))
-            members.update(self.__dict__)
-            members.update(f(self))
-            return sorted(members)
-    else:
-        # http://bugs.python.org/issue12166
+    # http://bugs.python.org/issue12166
 
-        @wraps(f)
-        def override__dir__wrapper(self):
-            members = set(object.__dir__(self))
-            members.update(f(self))
-            return sorted(members)
+    @wraps(f)
+    def override__dir__wrapper(self):
+        members = set(object.__dir__(self))
+        members.update(f(self))
+        return sorted(members)
 
     return override__dir__wrapper
 

--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -26,6 +26,7 @@ The supported time formats are:
   mxDateTime mx.DateTime object                              utc
   frac_year  YYYY.ffffff = date as a floating point year     utc
   plotdate   Matplotlib plotdate (days since year 0)         utc
+  cxotime    CxoTime class object                            varies
 ============ ==============================================  =======
 
 Each of these formats has an associated time system, which must be one of:

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import Chandra.Time
 from Chandra.Time import DateTime, convert, convert_vals, date2secs, secs2date
+from cxotime import CxoTime
 import unittest
 import time
 
@@ -100,6 +101,26 @@ class TestConvert(unittest.TestCase):
         self.assertEqual(DateTime('2012-01-01T00:00:00').mjd, 55926.999233981)
         self.assertEqual(DateTime('2013-01-01T00:00:00').mjd, 56292.999222407)
 
+    def test_cxotime_scalar(self):
+        date = '1998:001:00:00:01.234'
+        tm = CxoTime(date)
+        dt = DateTime(tm)
+        self.assertEqual(dt.date, date)
+
+        tm2 = dt.cxotime
+        self.assertTrue(isinstance(tm2, CxoTime))
+        self.assertEqual(tm2.yday, date)
+
+    def test_cxotime_array(self):
+        dates = ['2012:001:01:02:03.123', '2013:001:01:02:03.456']
+        tm = CxoTime(dates)
+        dt = DateTime(tm)
+        self.assertTrue(np.all(dt.date == dates))
+
+        tm2 = dt.cxotime
+        self.assertTrue(isinstance(tm2, CxoTime))
+        self.assertTruec(np.all(tm2.yday == dates))
+
     def test_plotdate(self):
         """
         Validate against cxctime2plotdate and round-trip
@@ -130,7 +151,7 @@ class TestConvert(unittest.TestCase):
     def test_year_doy(self):
         self.assertEqual(DateTime(20483020.0).year_doy, '1998:238')
         self.assertEqual(DateTime('2004:121').date, '2004:121:12:00:00.000')
-        
+
     def test_year_mon_day(self):
         self.assertEqual(DateTime('2004:121').year_mon_day, '2004-04-30')
         self.assertEqual(DateTime('2007-01-01').date, '2007:001:12:00:00.000')

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from Chandra.Time import DateTime, convert, convert_vals, date2secs, secs2date
+from ..Time import DateTime, convert, convert_vals, date2secs, secs2date
 from cxotime import CxoTime
 import time
 

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -1,270 +1,261 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import Chandra.Time
+
+import numpy as np
 from Chandra.Time import DateTime, convert, convert_vals, date2secs, secs2date
 from cxotime import CxoTime
-import unittest
 import time
 
-try:
-    import mx.DateTime
-    HAS_MX_DATETIME = True
-except ImportError:
-    HAS_MX_DATETIME = False
 
-try:
-    import numpy as np
-    HAS_NUMPY = True
-except ImportError:
-    HAS_NUMPY = False
-
-
-class TestFastConvert(unittest.TestCase):
-    def test_convert_vals_scalar(self):
-        fmts = ['date', 'secs', 'jd', 'mjd', 'fits', 'caldate']
-        vals = {fmt: getattr(DateTime('2012:001'), fmt) for fmt in fmts}
-        for fmt_in in fmts:
-            val = vals[fmt_in]
-            for fmt_out in fmts:
-                if fmt_in != fmt_out:
-                    convert_val = convert_vals(val, fmt_in, fmt_out)
-                    convert_back = convert_vals(convert_val, fmt_out, fmt_in)
-                    if val != convert_back:
-                        print(fmt_in, fmt_out, val, convert_back)
-                    self.assertEqual(convert_val, getattr(DateTime(val, format=fmt_in), fmt_out))
-                    self.assertEqual(val, convert_back)
-
-    def test_convert_vals_array(self):
-        fmts = ['date', 'secs', 'jd', 'mjd', 'fits', 'caldate']
-        vals = {fmt: getattr(DateTime(['2012:001', '2000:001']), fmt) for fmt in fmts}
-        for fmt_in in fmts:
-            val = vals[fmt_in]
-            for fmt_out in fmts:
-                if fmt_in != fmt_out:
-                    convert_val = convert_vals(val, fmt_in, fmt_out)
-                    convert_back = convert_vals(convert_val, fmt_out, fmt_in)
-                    self.assertTrue(np.all(val == convert_back))
-
-    def test_date2secs(self):
-        vals = DateTime(['2012:001', '2000:001'])
-        self.assertTrue(np.all(date2secs(vals.date) == vals.secs))
-
-    def test_secs2date(self):
-        vals = DateTime(['2012:001', '2000:001'])
-        self.assertTrue(np.all(secs2date(vals.secs) == vals.date))
+def test_convert_vals_scalar():
+    fmts = ['date', 'secs', 'jd', 'mjd', 'fits', 'caldate']
+    vals = {fmt: getattr(DateTime('2012:001'), fmt) for fmt in fmts}
+    for fmt_in in fmts:
+        val = vals[fmt_in]
+        for fmt_out in fmts:
+            if fmt_in != fmt_out:
+                convert_val = convert_vals(val, fmt_in, fmt_out)
+                convert_back = convert_vals(convert_val, fmt_out, fmt_in)
+                if val != convert_back:
+                    print(fmt_in, fmt_out, val, convert_back)
+                assert convert_val == getattr(DateTime(val, format=fmt_in), fmt_out)
+                assert val == convert_back
 
 
-class TestConvert(unittest.TestCase):
-    def test_mxDateTime_in(self):
-        self.assertEqual(convert('1998-01-01 00:00:30'), 93.184)
+def test_convert_vals_array():
+    fmts = ['date', 'secs', 'jd', 'mjd', 'fits', 'caldate']
+    vals = {fmt: getattr(DateTime(['2012:001', '2000:001']), fmt) for fmt in fmts}
+    for fmt_in in fmts:
+        val = vals[fmt_in]
+        for fmt_out in fmts:
+            if fmt_in != fmt_out:
+                convert_val = convert_vals(val, fmt_in, fmt_out)
+                convert_back = convert_vals(convert_val, fmt_out, fmt_in)
+                assert np.all(val == convert_back)
 
-    def test_mxDateTime_out(self):
-        if HAS_MX_DATETIME:
-            d = convert(93.184, fmt_out='mxDateTime')
-            self.assertEqual(d.date, '1998-01-01')
-            self.assertEqual(d.time, '00:00:30.00')
 
-    def test_init_from_mxDateTime(self):
-        if HAS_MX_DATETIME:
-            mxd = DateTime('1999-01-01 12:13:14').mxDateTime
-            self.assertEqual(DateTime(mxd).fits, '1999-01-01T12:14:18.184')
-            self.assertEqual(DateTime(mxd).mxDateTime.strftime('%c'),
-                             'Fri Jan  1 12:13:14 1999')
+def test_date2secs():
+    vals = DateTime(['2012:001', '2000:001'])
+    assert np.all(date2secs(vals.date) == vals.secs)
 
-    def test_iso(self):
-        self.assertEqual(convert(93.184, fmt_out='iso'), '1998-01-01 00:00:30.000')
-        self.assertEqual(convert(93.184, fmt_out='iso'), '1998-01-01 00:00:30.000')
-        self.assertEqual(DateTime(93.184).iso,           '1998-01-01 00:00:30.000')
-        self.assertEqual(DateTime('1998-01-01 00:00:30.000').secs, 93.184)
-        self.assertEqual(DateTime('1998-01-01 00:00:30').secs, 93.184)
-        self.assertEqual(DateTime('1998-1-1 0:0:1.111').secs, 64.295)
 
-    def test_secs(self):
-        self.assertEqual('%.3f' % DateTime(20483020.).secs, '20483020.000')
-        self.assertEqual(DateTime(20483020.).date, '1998:238:01:42:36.816')
-        self.assertAlmostEqual(DateTime('2012:001:00:00:00.000').secs,
-                         441763266.18399996, places=6)
-        self.assertEqual(DateTime(473385667.18399996).date, '2013:001:00:00:00.000')
+def test_secs2date():
+    vals = DateTime(['2012:001', '2000:001'])
+    assert np.all(secs2date(vals.secs) == vals.date)
 
-    def test_fits2secs(self):
-        self.assertEqual(convert('1998-01-01T00:00:30'), 30)
 
-    def test_fits2unix(self):
-        self.assertEqual(convert('1998-01-01T00:00:30', fmt_out='unix'), 883612766.816)
-        self.assertEqual(convert('2007-01-01T00:00:00', fmt_out='unix'), 1167609534.816)
-        self.assertEqual(DateTime('2007-01-01T00:00:00').unix, 1167609534.816)
+def test_mxDateTime_in():
+    assert convert('1998-01-01 00:00:30') == 93.184
 
-    def test_jd(self):
-        self.assertEqual(DateTime('2007-01-01T00:00:00').jd, 2454101.4992455561)
 
-    def test_mjd(self):
-        self.assertEqual(DateTime('2007-01-01T00:00:00').mjd, 54100.999245555999)
-        self.assertEqual(DateTime('2012-01-01T00:00:00').mjd, 55926.999233981)
-        self.assertEqual(DateTime('2013-01-01T00:00:00').mjd, 56292.999222407)
+def test_iso():
+    assert convert(93.184, fmt_out='iso') == '1998-01-01 00:00:30.000'
+    assert convert(93.184, fmt_out='iso') == '1998-01-01 00:00:30.000'
+    assert DateTime(93.184).iso == '1998-01-01 00:00:30.000'
+    assert DateTime('1998-01-01 00:00:30.000').secs == 93.184
+    assert DateTime('1998-01-01 00:00:30').secs == 93.184
+    assert DateTime('1998-1-1 0:0:1.111').secs == 64.295
 
-    def test_cxotime_scalar(self):
-        date = '1998:001:00:00:01.234'
-        tm = CxoTime(date)
-        dt = DateTime(tm)
-        self.assertEqual(dt.date, date)
 
-        tm2 = dt.cxotime
-        self.assertTrue(isinstance(tm2, CxoTime))
-        self.assertEqual(tm2.yday, date)
+def test_secs():
+    assert '%.3f' % DateTime(20483020.).secs == '20483020.000'
+    assert DateTime(20483020.).date == '1998:238:01:42:36.816'
+    assert np.isclose(DateTime('2012:001:00:00:00.000').secs, 441763266.18399996)
+    assert DateTime(473385667.18399996).date == '2013:001:00:00:00.000'
 
-    def test_cxotime_array(self):
-        dates = ['2012:001:01:02:03.123', '2013:001:01:02:03.456']
-        tm = CxoTime(dates)
-        dt = DateTime(tm)
-        self.assertTrue(np.all(dt.date == dates))
 
-        tm2 = dt.cxotime
-        self.assertTrue(isinstance(tm2, CxoTime))
-        self.assertTruec(np.all(tm2.yday == dates))
+def test_fits2secs():
+    assert convert('1998-01-01T00:00:30') == 30
 
-    def test_plotdate(self):
-        """
-        Validate against cxctime2plotdate and round-trip
-        >>> cxctime2plotdate([DateTime('2010:001').secs])
-        array([ 733773.5])
-        """
-        pd = DateTime('2010:001').plotdate
-        self.assertEqual(pd, 733773.5)
-        self.assertEqual(DateTime(pd, format='plotdate').date, '2010:001:12:00:00.000')
 
-    def test_greta(self):
-        self.assertEqual(DateTime('2007001.000000000').date, '2007:001:00:00:00.000')
-        self.assertEqual(DateTime('2007001.0').date, '2007:001:00:00:00.000')
-        self.assertEqual(DateTime(2007001.0).date, '2007:001:00:00:00.000')
-        self.assertEqual(DateTime('2007001.010203').date, '2007:001:01:02:03.000')
-        self.assertEqual(DateTime('2007001.01020304').date, '2007:001:01:02:03.040')
-        self.assertEqual(DateTime('2007:001:01:02:03.40').greta, '2007001.010203400')
-        self.assertEqual(DateTime('2007:001:00:00:00.000').greta, '2007001.000000000')
+def test_fits2unix():
+    assert convert('1998-01-01T00:00:30', fmt_out='unix') == 883612766.816
+    assert convert('2007-01-01T00:00:00', fmt_out='unix') == 1167609534.816
+    assert DateTime('2007-01-01T00:00:00').unix == 1167609534.816
 
-    def test_stop_day(self):
-        self.assertEqual(DateTime('1996365.010203').day_end().iso, '1996-12-31 00:00:00.000')
-        self.assertEqual(DateTime('1996366.010203').day_end().iso, '1997-01-01 00:00:00.000')
 
-    def test_start_day(self):
-        self.assertEqual(DateTime('1996365.010203').day_start().iso, '1996-12-30 00:00:00.000')
-        self.assertEqual(DateTime('1996367.010203').day_start().iso, '1997-01-01 00:00:00.000')
+def test_jd():
+    assert DateTime('2007-01-01T00:00:00').jd == 2454101.4992455561
 
-    def test_year_doy(self):
-        self.assertEqual(DateTime(20483020.0).year_doy, '1998:238')
-        self.assertEqual(DateTime('2004:121').date, '2004:121:12:00:00.000')
 
-    def test_year_mon_day(self):
-        self.assertEqual(DateTime('2004:121').year_mon_day, '2004-04-30')
-        self.assertEqual(DateTime('2007-01-01').date, '2007:001:12:00:00.000')
+def test_mjd():
+    assert DateTime('2007-01-01T00:00:00').mjd == 54100.999245555999
+    assert DateTime('2012-01-01T00:00:00').mjd == 55926.999233981
+    assert DateTime('2013-01-01T00:00:00').mjd == 56292.999222407
 
-    def test_add(self):
-        self.assertEqual((DateTime('2007-01-01') + 7).date, DateTime('2007-01-08').date)
 
-    def test_add_array(self):
-        if HAS_NUMPY:
-            dates_in = DateTime(np.array(['2007-01-01',
-                                          '2008-02-01']))
-            dates_out = dates_in + np.array([3, 4])
-            dates_exp = DateTime(np.array(['2007-01-04',
-                                           '2008-02-05']))
-            self.assertTrue(np.all(dates_out.date == dates_exp.date))
+def test_cxotime_scalar():
+    date = '1998:001:00:00:01.234'
+    tm = CxoTime(date)
+    dt = DateTime(tm)
+    assert dt.date == date
 
-    def test_sub_days(self):
-        self.assertEqual((DateTime('2007-01-08') - 7).date, DateTime('2007-01-01').date)
+    tm2 = dt.cxotime
+    assert isinstance(tm2, CxoTime)
+    assert tm2.utc.yday == date
 
-    def test_sub_datetimes(self):
-        self.assertEqual(DateTime('2007-01-08') - DateTime('2007-01-01'), 7)
 
-    def test_sub_datetimes_array(self):
-        if HAS_NUMPY:
-            dates_1 = DateTime(np.array(['2007-01-08',
-                                         '2008-01-08']))
-            dates_2 = DateTime(np.array(['2007-01-01',
-                                         '2008-01-02']))
-            delta_days = dates_1 - dates_2
-            self.assertTrue(np.all(delta_days == np.array([7, 6])))
+def test_cxotime_array():
+    dates = ['2012:001:01:02:03.123', '2013:001:01:02:03.456']
+    tm = CxoTime(dates)
+    dt = DateTime(tm)
+    assert np.all(dt.date == dates)
 
-    def test_init_from_DateTime(self):
-        date1 = DateTime('2001:001')
-        date2 = DateTime(date1)
-        self.assertEqual(date1.greta, date2.greta)
+    tm2 = dt.cxotime
+    assert isinstance(tm2, CxoTime)
+    assert np.all(tm2.utc.yday == dates)
 
-    def test_frac_year(self):
-        date1 = DateTime('1999:170:01:02:03.232')
-        date2 = DateTime(date1.frac_year, format='frac_year')
-        self.assertEqual(date1.date, date2.date)
-        date1 = DateTime('2001:180:00:00:00')
-        self.assertAlmostEqual(date1.frac_year, 2001 + 179. / 365.)
 
-    def test_leapsec_2015(self):
-        """
-        Tests for end of June 2015 leap second (PR #15).
-        """
-        # Test that there are 4 clock ticks where one usually expects 3
-        t1 = DateTime('2015-06-30 23:59:59').secs
-        t2 = DateTime('2015-07-01 00:00:02').secs
-        self.assertAlmostEqual(t2 - t1, 4.0)
-        # Test that a diff from a time before to the middle of the leap second is consistent
-        t1 = DateTime('2015-06-30 23:59:59').secs
-        t2 = DateTime('2015-06-30 23:59:60.5').secs
-        self.assertAlmostEqual(t2 - t1, 1.5)
-        # Test that a diff from the beginning of the leap second to the beginning of the next
-        # day is no longer than a second
-        t1 = DateTime('2015-06-30 23:59:60.').secs
-        t2 = DateTime('2015-07-01 00:00:00').secs
-        self.assertAlmostEqual(t2 - t1, 1.0)
+def test_plotdate():
+    """
+    Validate against cxctime2plotdate and round-trip
+    >>> cxctime2plotdate([DateTime('2010:001').secs])
+    array([ 733773.5])
+    """
+    pd = DateTime('2010:001').plotdate
+    assert pd == 733773.5
+    assert DateTime(pd, format='plotdate').date == '2010:001:12:00:00.000'
 
-    def test_leapsec_2016(self):
-        """
-        Tests for end of 2016 leap second. (PR #23).
-        """
-        # Test that there are 4 clock ticks where one usually expects 3
-        t1 = DateTime('2016-12-31 23:59:59').secs
-        t2 = DateTime('2017-01-01 00:00:02').secs
-        self.assertAlmostEqual(t2 - t1, 4.0)
-        # Test that a diff from a time before to the middle of the leap second is consistent
-        t1 = DateTime('2016-12-31 23:59:59').secs
-        t2 = DateTime('2016-12-31 23:59:60.5').secs
-        self.assertAlmostEqual(t2 - t1, 1.5)
-        # Test that a diff from the beginning of the leap second to the beginning of the year
-        # is no longer than a second
-        t1 = DateTime('2016-12-31 23:59:60.').secs
-        t2 = DateTime('2017-01-01 00:00:00').secs
-        self.assertAlmostEqual(t2 - t1, 1.0)
 
-    def test_date_now(self):
-        """
-        Make sure that instantiating a DateTime object as NOW uses the
-        the time at creation, not the time at attribute access.
-        """
-        date1 = DateTime()
-        date1_date = date1.date
-        time.sleep(1)
-        self.assertEqual(date1.date, date1_date)
+def test_greta():
+    assert DateTime('2007001.000000000').date == '2007:001:00:00:00.000'
+    assert DateTime('2007001.0').date == '2007:001:00:00:00.000'
+    assert DateTime(2007001.0).date == '2007:001:00:00:00.000'
+    assert DateTime('2007001.010203').date == '2007:001:01:02:03.000'
+    assert DateTime('2007001.01020304').date == '2007:001:01:02:03.040'
+    assert DateTime('2007:001:01:02:03.40').greta == '2007001.010203400'
+    assert DateTime('2007:001:00:00:00.000').greta == '2007001.000000000'
 
-    def test_date_attributes(self):
-        t = DateTime(['2015:160:02:24:01.250',
-                      '2015:161:03:24:02.250',
-                      '2015:162:04:24:03.250'])
-        for attr, vals in (('year', np.array([2015, 2015, 2015])),
-                           ('yday', np.array([160, 161, 162])),
-                           ('hour', np.array([2, 3, 4])),
-                           ('min', np.array([24, 24, 24])),
-                           ('sec', np.array([1.25, 2.25, 3.25])),
-                           ('mon', np.array([6, 6, 6])),
-                           ('day', np.array([9, 10, 11])),
-                           ('wday', np.array([1, 2, 3]))):
-            self.assertTrue(np.all(getattr(t, attr) == vals))
 
-        t = DateTime('2015:160:02:24:00.250')
-        for attr, val in (('year', 2015),
-                          ('yday', 160),
-                          ('hour', 2),
-                          ('min',  24),
-                          ('sec',  0.25),
-                          ('mon',  6),
-                          ('day',  9),
-                          ('wday', 1)):
-            self.assertTrue(getattr(t, attr) == val)
+def test_stop_day():
+    assert DateTime('1996365.010203').day_end().iso == '1996-12-31 00:00:00.000'
+    assert DateTime('1996366.010203').day_end().iso == '1997-01-01 00:00:00.000'
 
-if __name__ == '__main__':
-    unittest.main()
+
+def test_start_day():
+    assert DateTime('1996365.010203').day_start().iso == '1996-12-30 00:00:00.000'
+    assert DateTime('1996367.010203').day_start().iso == '1997-01-01 00:00:00.000'
+
+
+def test_year_doy():
+    assert DateTime(20483020.0).year_doy == '1998:238'
+    assert DateTime('2004:121').date == '2004:121:12:00:00.000'
+
+
+def test_year_mon_day():
+    assert DateTime('2004:121').year_mon_day == '2004-04-30'
+    assert DateTime('2007-01-01').date == '2007:001:12:00:00.000'
+
+
+def test_add():
+    assert (DateTime('2007-01-01') + 7).date == DateTime('2007-01-08').date
+
+
+def test_add_array():
+    dates_in = DateTime(np.array(['2007-01-01', '2008-02-01']))
+    dates_out = dates_in + np.array([3, 4])
+    dates_exp = DateTime(np.array(['2007-01-04', '2008-02-05']))
+    assert np.all(dates_out.date == dates_exp.date)
+
+
+def test_sub_days():
+    assert (DateTime('2007-01-08') - 7).date == DateTime('2007-01-01').date
+
+
+def test_sub_datetimes():
+    assert DateTime('2007-01-08') - DateTime('2007-01-01') == 7
+
+
+def test_sub_datetimes_array():
+    dates_1 = DateTime(np.array(['2007-01-08', '2008-01-08']))
+    dates_2 = DateTime(np.array(['2007-01-01', '2008-01-02']))
+    delta_days = dates_1 - dates_2
+    assert np.all(delta_days == np.array([7, 6]))
+
+
+def test_init_from_DateTime():
+    date1 = DateTime('2001:001')
+    date2 = DateTime(date1)
+    assert date1.greta == date2.greta
+
+
+def test_frac_year():
+    date1 = DateTime('1999:170:01:02:03.232')
+    date2 = DateTime(date1.frac_year, format='frac_year')
+    assert date1.date == date2.date
+    date1 = DateTime('2001:180:00:00:00')
+    assert np.isclose(date1.frac_year, 2001 + 179. / 365.)
+
+
+def test_leapsec_2015():
+    """
+    Tests for end of June 2015 leap second (PR #15).
+    """
+    # Test that there are 4 clock ticks where one usually expects 3
+    t1 = DateTime('2015-06-30 23:59:59').secs
+    t2 = DateTime('2015-07-01 00:00:02').secs
+    np.isclose(t2 - t1, 4.0)
+    # Test that a diff from a time before to the middle of the leap second is consistent
+    t1 = DateTime('2015-06-30 23:59:59').secs
+    t2 = DateTime('2015-06-30 23:59:60.5').secs
+    np.isclose(t2 - t1, 1.5)
+    # Test that a diff from the beginning of the leap second to the beginning of the next
+    # day is no longer than a second
+    t1 = DateTime('2015-06-30 23:59:60.').secs
+    t2 = DateTime('2015-07-01 00:00:00').secs
+    np.isclose(t2 - t1, 1.0)
+
+
+def test_leapsec_2016():
+    """
+    Tests for end of 2016 leap second. (PR #23).
+    """
+    # Test that there are 4 clock ticks where one usually expects 3
+    t1 = DateTime('2016-12-31 23:59:59').secs
+    t2 = DateTime('2017-01-01 00:00:02').secs
+    np.isclose(t2 - t1, 4.0)
+    # Test that a diff from a time before to the middle of the leap second is consistent
+    t1 = DateTime('2016-12-31 23:59:59').secs
+    t2 = DateTime('2016-12-31 23:59:60.5').secs
+    np.isclose(t2 - t1, 1.5)
+    # Test that a diff from the beginning of the leap second to the beginning of the year
+    # is no longer than a second
+    t1 = DateTime('2016-12-31 23:59:60.').secs
+    t2 = DateTime('2017-01-01 00:00:00').secs
+    np.isclose(t2 - t1, 1.0)
+
+
+def test_date_now():
+    """
+    Make sure that instantiating a DateTime object as NOW uses the
+    the time at creation, not the time at attribute access.
+    """
+    date1 = DateTime()
+    date1_date = date1.date
+    time.sleep(1)
+    assert date1.date == date1_date
+
+
+def test_date_attributes():
+    t = DateTime(['2015:160:02:24:01.250',
+                  '2015:161:03:24:02.250',
+                  '2015:162:04:24:03.250'])
+    for attr, vals in (('year', np.array([2015, 2015, 2015])),
+                       ('yday', np.array([160, 161, 162])),
+                       ('hour', np.array([2, 3, 4])),
+                       ('min', np.array([24, 24, 24])),
+                       ('sec', np.array([1.25, 2.25, 3.25])),
+                       ('mon', np.array([6, 6, 6])),
+                       ('day', np.array([9, 10, 11])),
+                       ('wday', np.array([1, 2, 3]))):
+        assert np.all(getattr(t, attr) == vals)
+
+    t = DateTime('2015:160:02:24:00.250')
+    for attr, val in (('year', 2015),
+                      ('yday', 160),
+                      ('hour', 2),
+                      ('min', 24),
+                      ('sec', 0.25),
+                      ('mon', 6),
+                      ('day', 9),
+                      ('wday', 1)):
+        assert getattr(t, attr) == val

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:parse functions are required to provide a named argument:PendingDeprecationWarning


### PR DESCRIPTION
## Description

Allow instantiating a DateTime object from a CxoTime object, and conversely getting a CxoTime object from DateTime using `tm.cxotime`.

One disappointing issue is that I discovered that CxoTime (astropy Time) is quite slow in creating scalar time objects, up to a factor of 15 slower (300 us vs. 20 us). For most applications this won't matter.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (added new unit tests).

Fixes #