### PR TITLE
Change so date like 2020:001 is midnight not noon

### DIFF
--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -181,6 +181,24 @@ year, month (1-12), day of month (1-31), hour (0-23), minute (0-59), second (0-6
 day of year (1-366), and day of week (0-6, where 0 is Monday).
 
 These are all referenced to UTC time.
+
+Date when hour, minutes, seconds not provided
+---------------------------------------------
+
+A date like ``2020:001`` will be taken as ``2020:001:00:00:00`` since version 4.0.
+Before 4.0, ``2020:001`` was ``2020:001:12:00:00``. To get the pre-4.0 behavior
+use the following code::
+
+    from Chandra.Time import use_noon_day_start
+
+    # Set to use 12:00:00 globally from now on.
+    use_noon_day_start()
+
+.. note::
+   You should do this globally once in your code at the beginning. There
+   is no way to revert to using 00:00:00 after calling ``use_noon_day_start``.
+   This impacts all code using ``DateTime``, not just the calls from your script.
+
 """
 import re
 from functools import wraps
@@ -189,6 +207,31 @@ import time
 
 import six
 import numpy as np
+
+# Time for dates specified without HMS. This was changed from '12:00:00' to
+# '00:00:00' in version 4.0 of Chandra.Time.  Call use_noon_day_start(True)
+# for compatibility with the pre-4.0 behavior.
+_DAY_START = '00:00:00'
+
+
+def use_noon_day_start():
+    """Set global default so date with no hours, min, sec uses 12:00:00.
+
+    A date like 2020:001 will be taken as 2020:001:00:00:00 since version 4.0.
+    Before 4.0, 2020:001 was 2020:001:12:00:00. To get the pre-4.0 behavior
+    use the following code.
+
+    NOTE: you should do this globally once in your code at the beginning. There
+    is no way to revert to using 00:00:00 after calling ``use_noon_day_start``.
+    ::
+
+      from Chandra.Time import use_noon_day_start
+
+      # Set to use 12:00:00 globally from now on.
+      use_noon_day_start()
+    """
+    global _DAY_START
+    _DAY_START = '12:00:00'
 
 
 def override__dir__(f):
@@ -337,7 +380,7 @@ time_styles = [TimeStyle(name='fits',
                          match_expr=RE['year_mon_day'],
                          ax3_fmt='f3',
                          ax3_sys='u',
-                         preprocess=lambda t: t + 'T12:00:00',
+                         preprocess=lambda t: t + 'T' + _DAY_START,
                          postprocess=lambda t: re.sub(r'T\d{2}:\d{2}:\d{2}\.\d+$', '', t),
                          ),
                TimeStyle(name='relday',
@@ -408,7 +451,7 @@ time_styles = [TimeStyle(name='fits',
                          match_expr=RE['year_doy'],
                          ax3_fmt='d3',
                          ax3_sys='u',
-                         preprocess=lambda t: t + ':12:00:00',
+                         preprocess=lambda t: t + ':' + _DAY_START,
                          postprocess=lambda t: re.sub(r':\d{2}:\d{2}:\d{2}\.\d+$', '', t),
                          ),
                TimeStyle(name='jd',

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 import pytest
 
-from ..Time import DateTime, convert, convert_vals, date2secs, secs2date
+from ..Time import DateTime, convert, convert_vals, date2secs, secs2date, use_noon_day_start
 from cxotime import CxoTime
 from astropy.time import Time
 
@@ -48,6 +48,18 @@ def test_secs2date():
 
 def test_mxDateTime_in():
     assert convert('1998-01-01 00:00:30') == 93.184
+
+
+def test_use_noon_day_start():
+    from .. import Time
+    assert Time._DAY_START == '00:00:00'
+    use_noon_day_start()
+    assert Time._DAY_START == '12:00:00'
+    tm = DateTime('2020:001')
+    assert tm.date == '2020:001:12:00:00.000'
+
+    # Set it back for rest of testing
+    Time._DAY_START = '00:00:00'
 
 
 def test_iso():
@@ -150,8 +162,8 @@ def test_plotdate():
     array([ 733773.5])
     """
     pd = DateTime('2010:001').plotdate
-    assert pd == 733773.5
-    assert DateTime(pd, format='plotdate').date == '2010:001:12:00:00.000'
+    assert pd == 733773.0
+    assert DateTime(pd, format='plotdate').date == '2010:001:00:00:00.000'
 
 
 def test_greta():
@@ -176,12 +188,12 @@ def test_start_day():
 
 def test_year_doy():
     assert DateTime(20483020.0).year_doy == '1998:238'
-    assert DateTime('2004:121').date == '2004:121:12:00:00.000'
+    assert DateTime('2004:121').date == '2004:121:00:00:00.000'
 
 
 def test_year_mon_day():
     assert DateTime('2004:121').year_mon_day == '2004-04-30'
-    assert DateTime('2007-01-01').date == '2007:001:12:00:00.000'
+    assert DateTime('2007-01-01').date == '2007:001:00:00:00.000'
 
 
 def test_add():


### PR DESCRIPTION
## Description

Based on popular demand, this changes Chandra.Time so that a date like ``2020:001`` will be taken as ``2020:001:00:00:00`` not ``2020:001:12:00:00``.

This adds a new function `use_noon_day_start` to provide back-compatibility where necessary. Cheta back-end data ingest is one intended use case.

This is likely to break at least a few things, so testing will be critical.

**This is targeted for shiny: both the skare3 branch and local branch here called `shiny`**.

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Integration testing will be done as part of skare3 / shiny testing

Closes #5 
(from 2012!)