### PR TITLE
Disable automatic astropy.iers downloads

### DIFF
--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -705,6 +705,10 @@ class DateTime(object):
         # then just convert to cxcsec (secs).
         try:
             secs = time_in.cxcsec
+            # For working in Chandra operations, possibly with no network access, we cannot
+            # allow auto downloads.
+            from astropy.utils import iers
+            iers.conf.auto_download = False
             import astropy.time
             assert isinstance(time_in, astropy.time.Time)
             time_in = secs


### PR DESCRIPTION
## Description

Prevent another problem related to automatic downloads for the leap second (https://github.com/astropy/astropy/issues/10523).

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Functional testing
