### PR TITLE
Allow bytes input to date2secs

### DIFF
--- a/Chandra/Time/Time.py
+++ b/Chandra/Time/Time.py
@@ -557,9 +557,17 @@ def convert_vals(vals, format_in, format_out):
     sys_out, fmt_out, dtype_out = get_style(format_out)
 
     vals, ndim = _make_array(vals)
+
+    # Allow passing bytes to axTime3 by converting to string here. This is
+    # actually silly since later in axTime3.convert_time() it gets encoded back
+    # to ASCII bytes. But since this package is largely deprecated we take the
+    # performance hit in the interest of simpler code.
+    if vals.dtype.kind == 'S':
+        vals = np.char.decode(vals, 'ascii')
+
     # If the input is already string-like then pass straight to convert_time.
     # Otherwise convert to string with repr().
-    if vals.dtype.char in 'SU':
+    if vals.dtype.kind == 'U':
         outs = [axTime3.convert_time(val, sys_in, fmt_in, sys_out, fmt_out)
                 for val in vals.flatten()]
     else:

--- a/Chandra/Time/tests/test_Time.py
+++ b/Chandra/Time/tests/test_Time.py
@@ -36,9 +36,16 @@ def test_convert_vals_array():
                 assert np.all(val == convert_back)
 
 
-def test_date2secs():
-    vals = DateTime(['2012:001', '2000:001'])
-    assert np.all(date2secs(vals.date) == vals.secs)
+@pytest.mark.parametrize('date_in', ('2012:001:00:00:00',
+                                     ['2012:001:00:00:00', '2000:001:00:00:00']))
+def test_date2secs(date_in):
+    vals = DateTime(date_in)
+    assert np.all(date2secs(date_in) == vals.secs)
+    if isinstance(date_in, str):
+        date_in_bytes = date_in.encode('ascii')
+    else:
+        date_in_bytes = [date.encode('ascii') for date in date_in]
+    assert np.all(date2secs(date_in_bytes) == vals.secs)
 
 
 def test_secs2date():


### PR DESCRIPTION
## Description

This allows `bytes` input to the `date2secs` function. Note that it does NOT allow `bytes` to be used to initialize a `DateTime` object. I tried that and things went badly wrong for reasons that were not immediately obvious.

The driver here is ensuring that `date2secs` will work with kadi commands archive v2, see https://github.com/sot/kadi/pull/212#issuecomment-1079129159.

## Testing

- [x] Passes unit tests on MacOS
- [n/a] Functional testing
