### PR TITLE
Use new location of duplicate_package_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ extensions = [
     )
 ]
 
-from testr.setup_helper import cmdclass, duplicate_package_info
+from testr.setup_helper import cmdclass
+from ska_helpers.setup_helper import duplicate_package_info
 
 name = "chandra_time"
 namespace = "Chandra.Time"


### PR DESCRIPTION
## Description

Use new/ska_helpers location of duplicate_package_info

This is a PR against the de-namespace branch.